### PR TITLE
update README.md for usage of [scrollObservable] with ion-slides in I…

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ export class AboutPage {
 }
 ```
 
+In case of using ion-slides in Ionic 2+, you can include your own scroll observable as below.
+
+```javascript
+@Component({
+    selector: 'page-image',
+    template: `
+      <ion-content #container padding>
+        <img [defaultImage]="https://www.placecage.com/1000/1000" [lazyLoad]="lazyLoadImage" [scrollObservable]="container.ionSlideWillChange" />
+      </ion-content>
+    `
+})
+export class AboutPage {
+    lazyLoadImage = 'https://hd.unsplash.com/photo-1431400445088-1750c997c6b5';
+}
+```
+
 See example folder for more usages.
 
 ### FAQ


### PR DESCRIPTION
hey, there.
I added the information how to use lazyLoading within  ```<ion-slides>``` tag in Ionic2+.
At the first time, I followed below usage, but it didn't work.

```javascript
@Component({
    selector: 'page-image',
    template: `
      <ion-content #container padding>
        <img [defaultImage]="https://www.placecage.com/1000/1000" [lazyLoad]="lazyLoadImage" [scrollObservable]="container.ionScroll" />
      </ion-content>
    `
})
export class AboutPage {
    lazyLoadImage = 'https://hd.unsplash.com/photo-1431400445088-1750c997c6b5';
}
```
so, I searched other usages on google, but there's no information about it.
then, I searched closed issue, and I found how to use it.

Ionic users will be confused using your library within ```<ion-slides>``` according to your current usage on README.md.

So I added usage, and make a pull request.
Thanks.