### PR TITLE
Added rect/isVisible logic to return faster when element is invisible. #333

### DIFF
--- a/src/lazyload-image.ts
+++ b/src/lazyload-image.ts
@@ -15,6 +15,9 @@ import { hasCssClassName, removeCssClassName, addCssClassName } from './utils';
 
 export function isVisible(element: HTMLElement, threshold = 0, _window: Window, scrollContainer?: HTMLElement) {
     const elementBounds = Rect.fromElement(element);
+    if (elementBounds === Rect.empty) {
+        return false;
+    }   
     const windowBounds = Rect.fromWindow(_window);
     elementBounds.inflate(threshold);
 

--- a/src/rect.ts
+++ b/src/rect.ts
@@ -15,7 +15,13 @@ export class Rect {
 
     static fromElement(element: HTMLElement): Rect {
         const { left, top, right, bottom } = element.getBoundingClientRect();
-        return new Rect(left, top, right, bottom);
+        
+        if (left === 0 && top === 0 && right === 0 && bottom === 0) {
+            return Rect.empty;
+        }
+        else {
+            return new Rect(left, top, right, bottom);
+        }
     }
 
     static fromWindow(_window: Window): Rect {

--- a/test/lazyload-image.test.ts
+++ b/test/lazyload-image.test.ts
@@ -242,6 +242,21 @@ describe('Lazy load image', () => {
 
             is(result, true);
         });
+
+        it('Should not be visible when image\'s rect is empty', () => {
+            const element = generateElement(0, 0, 0, 0);
+            const result = isVisible(element, 0, _window);
+
+            is(result, false);
+        });
+
+        it('Should not be visible when image\'s rect is empty and has an offset', () => {
+            const element = generateElement(0, 0, 0, 0);
+            const offset = 100;
+            const result = isVisible(element, offset, _window);
+
+            is(result, false);
+        })
     });
 
 });


### PR DESCRIPTION
Here's a late bugfix for #333.
I didn't add the logic to `fromWindow` since I can't imagine a situation where that would be necessary.