### PR TITLE
remove debounce time for the first time

### DIFF
--- a/src/lazyload-image.directive.ts
+++ b/src/lazyload-image.directive.ts
@@ -42,6 +42,7 @@ export class LazyLoadImageDirective implements OnChanges, AfterContentInit, OnDe
     private elementRef: ElementRef;
     private ngZone: NgZone;
     private scrollSubscription;
+    private debounceTime: any;
 
     constructor(el: ElementRef, ngZone: NgZone) {
         this.elementRef = el;
@@ -76,7 +77,7 @@ export class LazyLoadImageDirective implements OnChanges, AfterContentInit, OnDe
                 scrollObservable = getScrollListener(this.scrollTarget || windowTarget);
             }
             this.scrollSubscription = this.propertyChanges$.pipe(
-                debounceTime(10),
+                this.debounceTime ? this.debounceTime(10) : map(v => { this.debounceTime = debounceTime; return v }),
                 switchMap(props => scrollObservable.pipe(
                     lazyLoadImage(
                         this.elementRef.nativeElement,

--- a/src/lazyload-image.directive.ts
+++ b/src/lazyload-image.directive.ts
@@ -1,4 +1,4 @@
-import { Observable, ReplaySubject } from 'rxjs';
+import { Observable, ReplaySubject, SchedulerLike, MonoTypeOperatorFunction } from 'rxjs';
 import { switchMap, debounceTime, startWith, map } from 'rxjs/operators';
 import {
     AfterContentInit,
@@ -42,7 +42,7 @@ export class LazyLoadImageDirective implements OnChanges, AfterContentInit, OnDe
     private elementRef: ElementRef;
     private ngZone: NgZone;
     private scrollSubscription;
-    private debounceTime: any;
+    private debounceTime: (dueTime: number, scheduler?: SchedulerLike) => MonoTypeOperatorFunction<any>;
 
     constructor(el: ElementRef, ngZone: NgZone) {
         this.elementRef = el;

--- a/src/lazyload-image.directive.ts
+++ b/src/lazyload-image.directive.ts
@@ -1,5 +1,5 @@
 import { Observable, ReplaySubject } from 'rxjs';
-import { switchMap, debounceTime, startWith } from 'rxjs/operators';
+import { switchMap, debounceTime, startWith, map } from 'rxjs/operators';
 import {
     AfterContentInit,
     Directive,


### PR DESCRIPTION
I found that lazyload won't be triggered sometimes unless perform a scroll action after debounce time. So I removed debounce time for the first time.