### PR TITLE
✨  Support for SEO and SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Setup](#setup)
 - [Usages](#usages)
 - [Hooks](#hooks)
+- [Search Engine Optimization (SEO)](#seo)
 - [FAQ](#faq)
 - [Contributing](#contributing)
 
@@ -482,6 +483,22 @@ function finally(atter: Attributes) {
 }
 ```
 
+### isBot
+
+A function to check if the current user is a bot or not. Can be usefull for SSR and SEO.
+
+Default function:
+```ts
+export const isBot: IsBotFn = navigator => {
+  if (navigator && navigator.userAgent) {
+    return /googlebot|bingbot|yandex|baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp|duckduckbot/i.test(
+      navigator.userAgent
+    );
+  }
+  return false;
+};
+```
+
 ### preset
 
 Preset can be usefull when you want to set multible of the functions above.
@@ -515,6 +532,20 @@ LazyLoadImageModule.forRoot({
   finally: ({ element }) => console.log('The image is loaded', element)
 })
 ```
+
+## 🔎 Search Engine Optimization (SEO) <a name = "seo"></a>
+
+`ng-lazyload-image` are using the following strategy:
+
+### Server side rendering (SSR)
+
+- If the user is a bot (see `isBot` hook above), render all the images right away. (useful if the bot don't understand javascript)
+- If the user is not a bot (or if we can't decide), don't do anything and let the client fix the images (see below)
+
+### Client side
+
+- If the user is a bot (see `isBot` hook above), render all the images right away. (useful if the bot understand javascript)
+- If the user is not a bot (or if we can't decide), lazy load the images
 
 ## 🤔 FAQ <a name = "faq"></a>
 

--- a/src/hooks-factory.ts
+++ b/src/hooks-factory.ts
@@ -1,15 +1,23 @@
 import { scrollPreset } from './scroll-preset';
+import { ssrPreset } from './ssr-preset';
 import { HookSet, ModuleOptions } from './types';
+import { getNavigator } from './util';
 
 export function cretateHooks<E>(options?: ModuleOptions<E>): HookSet<any> {
-  if (!options) {
-    return scrollPreset;
+  const defaultPreset = scrollPreset;
+  const isBot = options && options.isBot ? options.isBot : scrollPreset.isBot;
+
+  if (isBot(getNavigator())) {
+    return ssrPreset;
+  } else if (!options) {
+    return defaultPreset;
   }
+
   const hooks = {};
   if (options.preset) {
     Object.assign(hooks, options.preset);
   } else {
-    Object.assign(hooks, scrollPreset);
+    Object.assign(hooks, defaultPreset);
   }
   Object.keys(options)
     .filter(key => key !== 'preset')

--- a/src/intersection-observer-preset/intersection-listener.ts
+++ b/src/intersection-observer-preset/intersection-listener.ts
@@ -1,7 +1,6 @@
 import { empty, Observable, Subject } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { Attributes } from '../types';
-import { isWindowDefined } from '../util';
 
 type ObserverOptions = {
   root?: Element;
@@ -17,7 +16,7 @@ function loadingCallback(entrys: IntersectionObserverEntry[]) {
 }
 
 export const getIntersectionObserver = (attributes: Attributes): Observable<IntersectionObserverEntry> => {
-  if (!attributes.scrollContainer && !isWindowDefined()) {
+  if (!attributes.scrollContainer) {
     return empty();
   }
 

--- a/src/lazyload-image.directive.ts
+++ b/src/lazyload-image.directive.ts
@@ -1,10 +1,11 @@
-import { AfterContentInit, Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnChanges, OnDestroy, Optional, Output, PLATFORM_ID } from '@angular/core';
 import { isPlatformServer } from '@angular/common';
-import { ReplaySubject, Observable, Subscription } from 'rxjs';
+import { AfterContentInit, Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnChanges, OnDestroy, Optional, Output, PLATFORM_ID } from '@angular/core';
+import { Observable, ReplaySubject, Subscription } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
 import { cretateHooks } from './hooks-factory';
 import { lazyLoadImage } from './lazyload-image';
 import { Attributes, HookSet, ModuleOptions } from './types';
+import { getNavigator } from './util';
 
 @Directive({
   selector: '[lazyLoad]'
@@ -47,8 +48,8 @@ export class LazyLoadImageDirective implements OnChanges, AfterContentInit, OnDe
   }
 
   ngAfterContentInit() {
-    // Disable lazy load image in server side
-    if (isPlatformServer(this.platformId)) {
+    // Don't do anything if SSR and the user isn't a bot
+    if (isPlatformServer(this.platformId) && !this.hooks.isBot(getNavigator())) {
       return null;
     }
 

--- a/src/scroll-preset/preset.ts
+++ b/src/scroll-preset/preset.ts
@@ -1,7 +1,6 @@
 import { startWith } from 'rxjs/operators';
 import { sharedPreset } from '../shared-preset/preset';
 import { Attributes, GetObservableFn, HookSet, IsVisibleFn } from '../types';
-import { isWindowDefined } from '../util';
 import { Rect } from './rect';
 import { getScrollListener } from './scroll-listener';
 
@@ -29,7 +28,7 @@ const getObservable: GetObservableFn<Event | string> = (attributes: Attributes) 
   if (attributes.scrollContainer) {
     return getScrollListener(attributes.scrollContainer);
   }
-  return getScrollListener(isWindowDefined() ? window : undefined);
+  return getScrollListener(window);
 };
 
 export const scrollPreset: HookSet<Event | string> = Object.assign({}, sharedPreset, {

--- a/src/scroll-preset/scroll-listener.ts
+++ b/src/scroll-preset/scroll-listener.ts
@@ -1,6 +1,5 @@
 import { empty, Observable, Subject } from 'rxjs';
 import { sampleTime, share, startWith } from 'rxjs/operators';
-import { isWindowDefined } from '../util';
 
 const scrollListeners = new WeakMap<any, Observable<any>>();
 
@@ -16,9 +15,7 @@ export function sampleObservable<T>(obs: Observable<T>, scheduler?: any): Observ
 // Typical, there will only be one observable per application
 export const getScrollListener = (scrollTarget?: HTMLElement | Window): Observable<Event | ''> => {
   if (!scrollTarget || typeof scrollTarget.addEventListener !== 'function') {
-    if (isWindowDefined()) {
-      console.warn('`addEventListener` on ' + scrollTarget + ' (scrollTarget) is not a function. Skipping this target');
-    }
+    console.warn('`addEventListener` on ' + scrollTarget + ' (scrollTarget) is not a function. Skipping this target');
     return empty();
   }
   const scrollListener = scrollListeners.get(scrollTarget);

--- a/src/shared-preset/__test__/preset.test.ts
+++ b/src/shared-preset/__test__/preset.test.ts
@@ -102,3 +102,57 @@ describe('Setup', () => {
     expect(source2.srcset).toBe(imagePath3);
   });
 });
+
+describe('isBot', () => {
+  test('Google bot is a bot', () => {
+    // Arrange
+    const navigator = {
+      userAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+    };
+
+    // Act
+    const result = sharedPreset.isBot(navigator as any);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  test('Firefox is not a bot', () => {
+    // Arrange
+    const navigator = {
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:70.0) Gecko/20100101 Firefox/70.0'
+    };
+
+    // Act
+    const result = sharedPreset.isBot(navigator as any);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  test('Chrome is not a bot', () => {
+    // Arrange
+    const navigator = {
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36'
+    };
+
+    // Act
+    const result = sharedPreset.isBot(navigator as any);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  test('Slack bot is a bot', () => {
+    // Arrange
+    const navigator = {
+      userAgent: 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)'
+    };
+
+    // Act
+    const result = sharedPreset.isBot(navigator as any);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+});

--- a/src/shared-preset/preset.ts
+++ b/src/shared-preset/preset.ts
@@ -1,4 +1,3 @@
-import { Observable, Subject } from 'rxjs';
 import {
   cssClassNames,
   hasCssClassName,
@@ -12,7 +11,7 @@ import {
   setImageAndSourcesToLazy,
   setImageAndSourcesToDefault
 } from '../util';
-import { FinallyFn, LoadImageFn, SetErrorImageFn, SetLoadedImageFn, SetupFn } from '../types';
+import { FinallyFn, LoadImageFn, SetErrorImageFn, SetLoadedImageFn, SetupFn, IsBotFn } from '../types';
 
 const end: FinallyFn = ({ element }) => addCssClassName(element, cssClassNames.loaded);
 
@@ -62,10 +61,20 @@ const setup: SetupFn = ({ element, defaultImagePath, useSrcset }) => {
   }
 };
 
+export const isBot: IsBotFn = navigator => {
+  if (navigator && navigator.userAgent) {
+    return /googlebot|bingbot|yandex|baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp|duckduckbot/i.test(
+      navigator.userAgent
+    );
+  }
+  return false;
+};
+
 export const sharedPreset = {
   finally: end,
   loadImage,
   setErrorImage,
   setLoadedImage,
-  setup
+  setup,
+  isBot
 };

--- a/src/ssr-preset/index.ts
+++ b/src/ssr-preset/index.ts
@@ -1,0 +1,1 @@
+export * from './preset';

--- a/src/ssr-preset/preset.ts
+++ b/src/ssr-preset/preset.ts
@@ -1,0 +1,21 @@
+import { of } from 'rxjs';
+import { GetObservableFn, HookSet, IsVisibleFn, LoadImageFn } from '../types';
+import { sharedPreset } from '../shared-preset/preset';
+
+const isVisible: IsVisibleFn<string> = () => {
+  return true;
+};
+
+const getObservable: GetObservableFn<string> = () => {
+  return of('load');
+};
+
+const loadImage: LoadImageFn = ({ imagePath }) => {
+  return [imagePath];
+};
+
+export const ssrPreset: HookSet<string> = Object.assign({}, sharedPreset, {
+  isVisible,
+  getObservable,
+  loadImage
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type SetErrorImageFn = (args: SetErrorImageProps) => void;
 export type SetupFn = (attributes: Attributes) => void;
 export type FinallyFn = (attributes: Attributes) => void;
 export type GetObservableFn<E> = (attributes: Attributes) => Observable<E>;
+export type IsBotFn = (navigator?: Navigator) => boolean;
 
 export interface HookSet<E> {
   getObservable: GetObservableFn<E>;
@@ -58,6 +59,7 @@ export interface HookSet<E> {
   setErrorImage: SetErrorImageFn;
   setup: SetupFn;
   finally: FinallyFn;
+  isBot: IsBotFn;
 }
 
 export interface ModuleOptions<T = any> extends Partial<HookSet<T>> {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,5 +1,5 @@
-export function isWindowDefined() {
-  return typeof window !== 'undefined';
+export function getNavigator(): Navigator | undefined {
+  return typeof window !== 'undefined' ? window.navigator : undefined;
 }
 
 export function isChildOfPicture(element: HTMLImageElement | HTMLDivElement): boolean {


### PR DESCRIPTION
See previous discussions here:  #394 

## Strategy: 

### On SSR

- If the user is a bot, render all the images right away. (useful if the bot don't understand javascript)
- If the user is not a bot (or if we can't decide), don't do anything and let the client fix the images (see below)

### Client side

- If the user is a bot, render all the images right away. (useful if the bot understand javascript)
- If the user is not a bot (or if we can't decide), lazy load the images

## New options:

- Added the hook `isBot`. That will decide if the user is a bot or not. Should return false if it can't decide. The default implementation will look at `userAgent`. It can, therefore, be useful for the server to forward it (see comment: https://github.com/tjoskar/ng-lazyload-image/pull/394#issuecomment-530359470)
