### PR TITLE
🐛  Remove constructor from scroll hooks to support Angular 8

### DIFF
--- a/src/scroll-hooks/__test__/hooks.test.ts
+++ b/src/scroll-hooks/__test__/hooks.test.ts
@@ -4,10 +4,11 @@ describe('isVisible', () => {
   class Sut extends ScrollHooks {
     constructor() {
       super();
-      this.getWindow = () => ({
-        innerHeight: 1000,
-        innerWidth: 1000,
-      } as any)
+      this.getWindow = () =>
+        ({
+          innerHeight: 1000,
+          innerWidth: 1000,
+        } as any);
     }
   }
   const hooks = new Sut();

--- a/src/scroll-hooks/__test__/hooks.test.ts
+++ b/src/scroll-hooks/__test__/hooks.test.ts
@@ -1,12 +1,16 @@
 import { ScrollHooks } from '../hooks';
 
 describe('isVisible', () => {
-  const getWindow = () =>
-    ({
-      innerHeight: 1000,
-      innerWidth: 1000,
-    } as any);
-  const hooks = new ScrollHooks(getWindow);
+  class Sut extends ScrollHooks {
+    constructor() {
+      super();
+      this.getWindow = () => ({
+        innerHeight: 1000,
+        innerWidth: 1000,
+      } as any)
+    }
+  }
+  const hooks = new Sut();
 
   const generateElement = (top: number, left: number, height = 300, width = 300): any => ({
     getBoundingClientRect: () => ({

--- a/src/scroll-hooks/hooks.ts
+++ b/src/scroll-hooks/hooks.ts
@@ -5,13 +5,8 @@ import { Attributes } from '../types';
 import { Rect } from './rect';
 
 export class ScrollHooks extends SharedHooks<Event | string> {
-  private readonly getWindow: () => Window;
+  protected getWindow = () => window;
   private readonly scrollListeners = new WeakMap<any, Observable<any>>();
-
-  constructor(getWindow = () => window) {
-    super();
-    this.getWindow = getWindow;
-  }
 
   getObservable(attributes: Attributes<Event | string>): Observable<Event | string> {
     if (this.skipLazyLoading()) {


### PR DESCRIPTION
Fixes #476 