### PR TITLE
Allow usage of attributes in hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ setLoadedImage(imagePath: string, attributes: Attributes): void; // Logic to set
 setErrorImage(error: Error, attributes: Attributes): void; // Logic to set the error image
 setup(attributes: Attributes): void; // Set up function
 finally(attributes: Attributes): void; // Teardown function
-isBot(attributes: Attributes): boolean; // Is the user a bot?
+isBot(attributes?: Attributes): boolean; // Is the user a bot?
 isDisabled(): boolean; // Should the lazyload mechanism be disbled?
 skipLazyLoading(attributes: Attributes): boolean; // Should we load the image ASAP?
 ```

--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ import { isPlatformServer } from '@angular/common';
 import { IntersectionObserverHooks, Attributes } from 'ng-lazyload-image';
 
 class LazyLoadImageHooks extends IntersectionObserverHooks {
-  isBot(attributes: Attributes) {
+  isBot(attributes?: Attributes) {
     // Check if the user is a bot or not.
     this.navigator; // Is the same as `window.navigator` if window is defined otherwise undefined.
     isPlatformServer(this.platformId); // True if the code is running on the server

--- a/src/intersection-observer-hooks/hooks.ts
+++ b/src/intersection-observer-hooks/hooks.ts
@@ -9,7 +9,7 @@ export class IntersectionObserverHooks extends SharedHooks<{ isIntersecting: boo
   private readonly uniqKey = {};
 
   getObservable(attributes: Attributes<{ isIntersecting: boolean }>): Observable<{ isIntersecting: boolean }> {
-    if (this.skipLazyLoading()) {
+    if (this.skipLazyLoading(attributes)) {
       return of({ isIntersecting: true });
     }
     if (attributes.customObservable) {

--- a/src/scroll-hooks/hooks.ts
+++ b/src/scroll-hooks/hooks.ts
@@ -9,7 +9,7 @@ export class ScrollHooks extends SharedHooks<Event | string> {
   private readonly scrollListeners = new WeakMap<any, Observable<any>>();
 
   getObservable(attributes: Attributes<Event | string>): Observable<Event | string> {
-    if (this.skipLazyLoading()) {
+    if (this.skipLazyLoading(attributes)) {
       return of('load');
     } else if (attributes.customObservable) {
       return attributes.customObservable.pipe(startWith(''));

--- a/src/shared-hooks/hooks.ts
+++ b/src/shared-hooks/hooks.ts
@@ -73,10 +73,10 @@ export abstract class SharedHooks<E> extends Hooks<E> {
   }
 
   skipLazyLoading(attributes: Attributes): boolean {
-    return this.isBot();
+    return this.isBot(attributes);
   }
 
-  isBot(): boolean {
+  isBot(attributes?: Attributes): boolean {
     if (this.navigator?.userAgent) {
       return /googlebot|bingbot|yandex|baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp|duckduckbot/i.test(
         this.navigator.userAgent

--- a/src/shared-hooks/hooks.ts
+++ b/src/shared-hooks/hooks.ts
@@ -20,7 +20,7 @@ export abstract class SharedHooks<E> extends Hooks<E> {
   }
 
   loadImage(attributes: Attributes): ObservableInput<string> {
-    if (this.skipLazyLoading()) {
+    if (this.skipLazyLoading(attributes)) {
       // Set the image right away for bots for better SEO
       return [attributes.imagePath];
     }
@@ -72,7 +72,7 @@ export abstract class SharedHooks<E> extends Hooks<E> {
     return isPlatformServer(this.platformId) && !this.isBot();
   }
 
-  skipLazyLoading(): boolean {
+  skipLazyLoading(attributes: Attributes): boolean {
     return this.isBot();
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export abstract class Hooks<E = unknown> {
   abstract setErrorImage(error: Error, attributes: Attributes): void;
   abstract setup(attributes: Attributes): void;
   abstract finally(attributes: Attributes): void;
-  abstract isBot(attributes: Attributes): boolean;
+  abstract isBot(attributes?: Attributes): boolean;
   abstract isDisabled(): boolean;
   abstract skipLazyLoading(attributes: Attributes): boolean;
   onDestroy(attributes: Attributes): void {}


### PR DESCRIPTION
Pass the attributes object to `skipLazyLoading` and `isBot` so that the lazy loading can be toggle on per image basis.

Fixes #483 