### PR TITLE
Don't add the loading class when there is not imagePath

### DIFF
--- a/src/shared-hooks/hooks.ts
+++ b/src/shared-hooks/hooks.ts
@@ -7,7 +7,9 @@ import { isChildOfPicture, isImageElement, setImage, setImageAndSourcesToDefault
 export abstract class SharedHooks<E> extends Hooks<E> {
   setup(attributes: Attributes): void {
     setImageAndSourcesToDefault(attributes.element, attributes.defaultImagePath, attributes.useSrcset);
-    addCssClassName(attributes.element, cssClassNames.loading);
+    if (attributes.imagePath) {
+      addCssClassName(attributes.element, cssClassNames.loading);
+    }
 
     if (hasCssClassName(attributes.element, cssClassNames.loaded)) {
       removeCssClassName(attributes.element, cssClassNames.loaded);


### PR DESCRIPTION
Don't put loading class when source image is falsy (null, undefined, etc).
Resolves #487 