### PR TITLE
Add "prerender" to the bot list so lazy loading won't be active when the prerender.io bot visits the page

### DIFF
--- a/src/shared-hooks/hooks.ts
+++ b/src/shared-hooks/hooks.ts
@@ -80,7 +80,7 @@ export abstract class SharedHooks<E> extends Hooks<E> {
 
   isBot(attributes?: Attributes): boolean {
     if (this.navigator?.userAgent) {
-      return /googlebot|bingbot|yandex|baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp|duckduckbot/i.test(
+      return /googlebot|bingbot|yandex|baiduspider|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator|whatsapp|duckduckbot|prerender/i.test(
         this.navigator.userAgent
       );
     }


### PR DESCRIPTION
I can bump the version and add the change to the changelog but I was not sure if I can do that so this is just the code yet