### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Default: `0`
 Number of px a image should be loaded before it is in view port
 
 ```html
-<img [defaultImage]="someDefaultImage" [lazyLoad]="imageToLazyLoad" offset="100" />
+<img [defaultImage]="someDefaultImage" [lazyLoad]="imageToLazyLoad" [offset]="100" />
 ```
 
 ##### scrollTarget (optional)


### PR DESCRIPTION
Improve documentation so renderer doesn't throw an error in a strict mode like this:

```
Error: app/modules/components/example.component.html:7:61 - error TS2322: Type 'string' is not assignable to type 'number'.

7     <div class="img" [lazyLoad]="profile.url" offset="100"></div>
```